### PR TITLE
Quote database name in CREATE statement

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -32,7 +32,7 @@ const create_db = async (host: string, username: string, password: string, db_na
   const client = connect(host, username, password);
 
   // TODO: provided engine type over parameters
-  const q = `CREATE DATABASE IF NOT EXISTS ${db_name} ENGINE = Atomic`;
+  const q = `CREATE DATABASE IF NOT EXISTS "${db_name}" ENGINE = Atomic`;
 
   try {
     await client.exec({


### PR DESCRIPTION
This makes it possible to use the tool on a database with a non-identifier name.