### PR TITLE
Resolve failing test

### DIFF
--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -31,7 +31,7 @@ describe('Migration tests', () => {
     expect(insertSpy).toHaveBeenCalledTimes(1);
 
     expect(execSpy).toHaveBeenNthCalledWith(1, {
-      query: 'CREATE DATABASE IF NOT EXISTS analytics ENGINE = Atomic',
+      query: 'CREATE DATABASE IF NOT EXISTS "analytics" ENGINE = Atomic',
       clickhouse_settings: {
         wait_end_of_query: 1,
       },


### PR DESCRIPTION
This resolves a failing test as a result of the change in https://github.com/VVVi/clickhouse-migrations/pull/9

Before:
![CleanShot 2024-05-31 at 08 57 09@2x](https://github.com/VVVi/clickhouse-migrations/assets/23254373/a82aac7d-140b-4ecf-8fb0-f9210888bfdd)

After:
![CleanShot 2024-05-31 at 08 57 27@2x](https://github.com/VVVi/clickhouse-migrations/assets/23254373/23c31706-8e81-487f-aa04-1c56ce8714dd)
