### PR TITLE
Add request timeout as cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ If the database provided in the `--db` option (or in `CH_MIGRATIONS_DB`) doesn't
       --db=<name>               Database name
       --migrations-home=<dir>   Migrations' directory
 
+  Optional options
+      --timeout=<value>         Client request timeout (milliseconds, default value 30000)
+
   Environment variables
       Instead of options can be used environment variables.
       CH_MIGRATIONS_HOST        Clickhouse hostname (--host)
@@ -38,13 +41,16 @@ If the database provided in the `--db` option (or in `CH_MIGRATIONS_DB`) doesn't
       CH_MIGRATIONS_PASSWORD    Password (--password)
       CH_MIGRATIONS_DB          Database name (--db)
       CH_MIGRATIONS_HOME        Migrations' directory (--migrations-home)
+      CH_MIGRATIONS_TIMEOUT     Client request timeout (--timeout)
 
   CLI examples
       clickhouse-migrations migrate --host=http://localhost:8123 
       --user=default --password='' --db=analytics 
       --migrations-home=/app/clickhouse/migrations
 
-      clickhouse-migrations migrate 
+      clickhouse-migrations migrate
+
+      clickhouse-migrations migrate --timeout=60000
 ```
 
 Migration file example:

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,9 +1,9 @@
-import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
+import type { ClickHouseClient } from '@clickhouse/client';
+import type { NodeClickHouseClientConfigOptions } from '@clickhouse/client/dist/client';
 import { Command } from 'commander';
 import fs from 'fs';
 import crypto from 'crypto';
-
 import { sql_queries, sql_sets } from './sql-parse';
 
 const log = (type: 'info' | 'error' = 'info', message: string, error?: string) => {
@@ -14,8 +14,14 @@ const log = (type: 'info' | 'error' = 'info', message: string, error?: string) =
   }
 };
 
-const connect = (host: string, username: string, password: string, db_name?: string): ClickHouseClient => {
-  const db_params: ClickhouseDbParams = {
+const connect = (
+  host: string,
+  username: string,
+  password: string,
+  db_name?: string,
+  timeout?: string,
+): ClickHouseClient => {
+  const db_params: NodeClickHouseClientConfigOptions = {
     host,
     username,
     password,
@@ -25,6 +31,11 @@ const connect = (host: string, username: string, password: string, db_name?: str
   if (db_name) {
     db_params.database = db_name;
   }
+
+  if (timeout) {
+    db_params.request_timeout = Number(timeout);
+  }
+
   return createClient(db_params);
 };
 
@@ -222,12 +233,13 @@ const migration = async (
   username: string,
   password: string,
   db_name: string,
+  timeout?: string,
 ): Promise<void> => {
   const migrations = get_migrations(migrations_home);
 
   await create_db(host, username, password, db_name);
 
-  const client = connect(host, username, password, db_name);
+  const client = connect(host, username, password, db_name, timeout);
 
   await init_migration_table(client);
 
@@ -249,8 +261,20 @@ const migrate = () => {
     .requiredOption('--password <password>', 'Password', process.env.CH_MIGRATIONS_PASSWORD)
     .requiredOption('--db <name>', 'Database name', process.env.CH_MIGRATIONS_DB)
     .requiredOption('--migrations-home <dir>', "Migrations' directory", process.env.CH_MIGRATIONS_HOME)
+    .option(
+      '--timeout <value>',
+      'Client request timeout (milliseconds, default value 30000)',
+      process.env.CH_MIGRATIONS_TIMEOUT,
+    )
     .action(async (options: CliParameters) => {
-      await migration(options.migrationsHome, options.host, options.user, options.password, options.db);
+      await migration(
+        options.migrationsHome,
+        options.host,
+        options.user,
+        options.password,
+        options.db,
+        options.timeout,
+      );
     });
 
   program.parse();

--- a/src/types/cli.d.ts
+++ b/src/types/cli.d.ts
@@ -1,21 +1,5 @@
 /// <reference types="node" />
 
-type ClickhouseDbParams = {
-  host: string;
-  connect_timeout?: number;
-  request_timeout?: number;
-  max_open_connections?: number;
-  compression?: { response?: boolean; request?: boolean };
-  username: string;
-  password: string;
-  application?: string;
-  database?: string;
-  clickhouse_settings?: ClickHouseSettings;
-  log?: { enable?: boolean; LoggerClass?: Logger };
-  tls?: { ca_cert: Buffer; cert?: Buffer; key?: Buffer };
-  session_id?: string;
-};
-
 type MigrationBase = {
   version: number;
   file: string;
@@ -25,7 +9,7 @@ type MigrationsRowData = {
   version: number;
   checksum: string;
   migration_name: string;
-}
+};
 
 type CliParameters = {
   migrationsHome: string;
@@ -33,8 +17,9 @@ type CliParameters = {
   user: string;
   password: string;
   db: string;
+  timeout?: string;
 };
 
 type QueryError = {
   message: string;
-}
+};


### PR DESCRIPTION
Adds the ability to override the default Clickhouse Client timeout through a new `--timeout` cli optional option.

https://clickhouse.com/docs/en/integrations/language-clients/javascript#configuration

Should resolve https://github.com/VVVi/clickhouse-migrations/issues/10 as well.

I have also imported the type `NodeClickHouseClientConfigOptions` from Clickhouse directly for typing the db_params, happy to move this back to how it was before if preferred.