### PR TITLE
Update ClickHouse to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
-        "@clickhouse/client": "^0.2.9",
+        "@clickhouse/client": "^1.4.0",
         "commander": "^11.1.0"
       },
       "bin": {
@@ -724,20 +724,20 @@
       "dev": true
     },
     "node_modules/@clickhouse/client": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-0.2.9.tgz",
-      "integrity": "sha512-KqQlO9vZNSLyhMWG9+0/VXqcUZrNk1Hybr9icgI/nLCoX8RD19BJsakZJj38IQvQxNUTxvcItm/kyu/gD/9LXA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.4.0.tgz",
+      "integrity": "sha512-O4mbFPM/wQtFck01ghYI2mnNHv9jSFEiQBsTCH4t6MKeGHNAPkJGaFGv+KycLTv6zjnQNjiUGdXDMVRema5SyA==",
       "dependencies": {
-        "@clickhouse/client-common": "0.2.9"
+        "@clickhouse/client-common": "1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@clickhouse/client-common": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-0.2.9.tgz",
-      "integrity": "sha512-ecXcegMbT4HYNWtGcfyidW6lNVRqPogbFMY5kfjJmz4IXJ4WZbQMwj2IQgemwFwE7jyia2OEwPIVfw1sNfDHRA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.4.0.tgz",
+      "integrity": "sha512-kglG8YyWnR1K24RckUf5ZdNTN0U0s+a1j/bpCO4ZjzjO87ICgWlXFVD22pZqSACW7/2IIi1IkzbwtxKI2s/MOw=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   "license": "MIT",
   "repository": "VVVi/clickhouse-migrations",
   "dependencies": {
-    "@clickhouse/client": "^0.2.9",
+    "@clickhouse/client": "^1.4.0",
     "commander": "^11.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^18.15.11",
-    "@typescript-eslint/parser": "^6.20.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
-    "eslint-plugin-prettier": "^5.1.3",
+    "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
     "ts-jest": "^29.1.2",

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import crypto from 'crypto';
 
 import { sql_queries, sql_sets } from './sql-parse';
+import { ClickHouseClientConfigOptions } from '@clickhouse/client';
 
 const log = (type: 'info' | 'error' = 'info', message: string, error?: string) => {
   if (type === 'info') {
@@ -15,7 +16,7 @@ const log = (type: 'info' | 'error' = 'info', message: string, error?: string) =
 };
 
 const connect = (host: string, username: string, password: string, db_name?: string): ClickHouseClient => {
-  const db_params: ClickhouseDbParams = {
+  const db_params: ClickHouseClientConfigOptions = {
     host,
     username,
     password,
@@ -51,13 +52,13 @@ const create_db = async (host: string, username: string, password: string, db_na
 
 const init_migration_table = async (client: ClickHouseClient): Promise<void> => {
   const q = `CREATE TABLE IF NOT EXISTS _migrations (
-      uid UUID DEFAULT generateUUIDv4(), 
+      uid UUID DEFAULT generateUUIDv4(),
       version UInt32,
-      checksum String, 
-      migration_name String, 
+      checksum String,
+      migration_name String,
       applied_at DateTime DEFAULT now()
-    ) 
-    ENGINE = MergeTree 
+    )
+    ENGINE = MergeTree
     ORDER BY tuple(applied_at)`;
 
   try {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -15,9 +15,9 @@ const log = (type: 'info' | 'error' = 'info', message: string, error?: string) =
   }
 };
 
-const connect = (host: string, username: string, password: string, db_name?: string): ClickHouseClient => {
+const connect = (url: string, username: string, password: string, db_name?: string): ClickHouseClient => {
   const db_params: ClickHouseClientConfigOptions = {
-    host,
+    url,
     username,
     password,
     application: 'clickhouse-migrations',

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -5,7 +5,6 @@ import { Command } from 'commander';
 import fs from 'fs';
 import crypto from 'crypto';
 import { sql_queries, sql_sets } from './sql-parse';
-import { ClickHouseClientConfigOptions } from '@clickhouse/client';
 
 const log = (type: 'info' | 'error' = 'info', message: string, error?: string) => {
   if (type === 'info') {

--- a/src/types/cli.d.ts
+++ b/src/types/cli.d.ts
@@ -1,21 +1,5 @@
 /// <reference types="node" />
 
-type ClickhouseDbParams = {
-  host: string;
-  connect_timeout?: number;
-  request_timeout?: number;
-  max_open_connections?: number;
-  compression?: { response?: boolean; request?: boolean };
-  username: string;
-  password: string;
-  application?: string;
-  database?: string;
-  clickhouse_settings?: ClickHouseSettings;
-  log?: { enable?: boolean; LoggerClass?: Logger };
-  tls?: { ca_cert: Buffer; cert?: Buffer; key?: Buffer };
-  session_id?: string;
-};
-
 type MigrationBase = {
   version: number;
   file: string;
@@ -25,7 +9,7 @@ type MigrationsRowData = {
   version: number;
   checksum: string;
   migration_name: string;
-}
+};
 
 type CliParameters = {
   migrationsHome: string;
@@ -37,4 +21,4 @@ type CliParameters = {
 
 type QueryError = {
   message: string;
-}
+};

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -31,7 +31,7 @@ describe('Migration tests', () => {
     expect(insertSpy).toHaveBeenCalledTimes(1);
 
     expect(execSpy).toHaveBeenNthCalledWith(1, {
-      query: 'CREATE DATABASE IF NOT EXISTS analytics ENGINE = Atomic',
+      query: 'CREATE DATABASE IF NOT EXISTS "analytics" ENGINE = Atomic',
       clickhouse_settings: {
         wait_end_of_query: 1,
       },

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -38,13 +38,13 @@ describe('Migration tests', () => {
     });
     expect(execSpy).toHaveBeenNthCalledWith(2, {
       query: `CREATE TABLE IF NOT EXISTS _migrations (
-      uid UUID DEFAULT generateUUIDv4(), 
+      uid UUID DEFAULT generateUUIDv4(),
       version UInt32,
-      checksum String, 
-      migration_name String, 
+      checksum String,
+      migration_name String,
       applied_at DateTime DEFAULT now()
-    ) 
-    ENGINE = MergeTree 
+    )
+    ENGINE = MergeTree
     ORDER BY tuple(applied_at)`,
       clickhouse_settings: {
         wait_end_of_query: 1,


### PR DESCRIPTION
A few changes in this PR:
- Update Clickhouse to 1.4.0
- Replace `ClickhouseDbParams` with official `ClickHouseClientConfigOptions` type from `@clickhouse/client`
- Use `url` for connection string instead of the deprecated `host` option