### PR TITLE
Support TLS Connection

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -40,13 +40,16 @@ const connect = (
   }
 
   if (ca_cert) {
-    db_params.tls = {
-      ca_cert: fs.readFileSync(ca_cert),
-    };
-
     if (cert && key) {
-      db_params.tls.cert = fs.readFileSync(cert);
-      db_params.tls.key = fs.readFileSync(key);
+      db_params.tls = {
+        ca_cert: fs.readFileSync(ca_cert),
+        cert: fs.readFileSync(cert),
+        key: fs.readFileSync(key),
+      };
+    } else {
+      db_params.tls = {
+        ca_cert: fs.readFileSync(ca_cert),
+      };
     }
   }
 

--- a/src/types/cli.d.ts
+++ b/src/types/cli.d.ts
@@ -19,6 +19,9 @@ type CliParameters = {
   db: string;
   dbEngine?: string;
   timeout?: string;
+  ca_cert?: string;
+  cert?: string;
+  key?: string;
 };
 
 type QueryError = {


### PR DESCRIPTION
This implements https://github.com/VVVi/clickhouse-migrations/issues/14.

I see there is another PR for this, but it hasn't been merged yet.

This handles both cases of `BasicTLSOptions` and `MutualTLSOptions` from the upstream `clickhouse-client` (these are inferred automatically):

```
interface BasicTLSOptions {
  ca_cert: Buffer
}

interface MutualTLSOptions {
  ca_cert: Buffer
  cert: Buffer
  key: Buffer
}
```

I'm currently running this fork in my environment successfully.