### PR TITLE
feat: opt-in ${VAR} environment-variable substitution in migration SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ If the database provided in the `--db` option (or in `CH_MIGRATIONS_DB`) doesn't
 
 For TLS/HTTPS connections, you can provide a custom CA certificate and optional client certificate/key via the `--ca-cert`, `--cert`, and `--key` options (or the `CH_MIGRATIONS_CA_CERT`, `CH_MIGRATIONS_CERT`, and `CH_MIGRATIONS_KEY` environment variables).
 
+### Environment variable substitution (optional)
+
+Set `CH_MIGRATIONS_SUBSTITUTE_ENV=true` to substitute `${VAR}` placeholders in migration files with the corresponding environment variables at apply time. It is off by default, so existing migrations are unaffected. A referenced-but-unset variable is a hard error (the placeholder is never left as a literal `${...}`).
+
+The checksum used to detect changed migrations is computed on the **raw file** (before substitution), so a committed migration stays stable across environments and secret rotations, and the substituted SQL is never stored in the `_migrations` table. This is useful for environment-specific, idempotent DDL — for example a dictionary whose `SOURCE(...)` points at a per-environment database:
+
+```sql
+CREATE OR REPLACE DICTIONARY my_db.dict_offers
+(
+    `id` UUID,
+    `name` String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(POSTGRESQL(HOST '${PG_HOST}' PORT ${PG_PORT} USER '${PG_USER}' PASSWORD '${PG_PASSWORD}' DB '${PG_DB}' TABLE 'offers'))
+LIFETIME(MIN 0 MAX 300)
+LAYOUT(COMPLEX_KEY_HASHED());
+```
+
+Substitution is textual (like `envsubst`) and does not SQL-escape values, so any value placed inside quotes must be escaping-safe.
+
 ```
   Usage
     $ clickhouse-migrations migrate <options>
@@ -63,6 +83,10 @@ For TLS/HTTPS connections, you can provide a custom CA certificate and optional 
                                 (optional) Skip database creation,
                                   set to 'true' to enable
                                   (--skip-db-creation)
+      CH_MIGRATIONS_SUBSTITUTE_ENV
+                                (optional) Substitute ${VAR} in migration
+                                  files from the environment at apply time,
+                                  set to 'true' to enable
 
 
   CLI executions examples

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import crypto from 'crypto';
 
-import { sql_queries, sql_sets } from './sql-parse';
+import { sql_queries, sql_sets, substitute_env } from './sql-parse';
 import { VERSION } from './version';
 
 const log = (type: 'info' | 'error' = 'info', message: string, error?: string) => {
@@ -261,9 +261,19 @@ const apply_migrations = async (
       continue;
     }
 
+    // Substitute ${VAR} from the environment (opt-in) at apply time only. The
+    // checksum above is over the raw file, so it stays stable across environments.
+    let sql: string;
+    try {
+      sql = substitute_env(content);
+    } catch (e: unknown) {
+      log('error', `the migration ${migration.file} has an error.`, e instanceof Error ? e.message : String(e));
+      process.exit(1);
+    }
+
     // Extract sql from the migration.
-    const queries = sql_queries(content);
-    const sets = sql_sets(content);
+    const queries = sql_queries(sql);
+    const sets = sql_sets(sql);
 
     for (const query of queries) {
       try {

--- a/src/sql-parse.ts
+++ b/src/sql-parse.ts
@@ -1,3 +1,28 @@
+// Substitute ${VAR} placeholders in migration content from environment variables.
+//
+// Opt-in via CH_MIGRATIONS_SUBSTITUTE_ENV=true, so existing migrations are
+// unaffected by default. Substitution happens at apply time only; callers
+// checksum the raw (pre-substitution) content, so a committed migration stays
+// stable across environments and secret rotations, and the substituted SQL is
+// never persisted. Useful for environment-specific, idempotent DDL such as a
+// dictionary whose SOURCE(...) points at a per-environment database.
+//
+// A referenced-but-unset variable throws (fail loud) rather than emitting a
+// literal ${...} into the SQL.
+const substitute_env = (content: string): string => {
+  if (process.env.CH_MIGRATIONS_SUBSTITUTE_ENV !== 'true') {
+    return content;
+  }
+
+  return content.replace(/\$\{(\w+)\}/g, (_match: string, name: string): string => {
+    const value = process.env[name];
+    if (value === undefined) {
+      throw new Error(`migration references \${${name}} but the environment variable ${name} is not set.`);
+    }
+    return value;
+  });
+};
+
 // Extract sql queries from migrations.
 const sql_queries = (content: string): string[] => {
   const queries = content
@@ -34,4 +59,4 @@ const sql_sets = (content: string) => {
   return sets;
 };
 
-export { sql_queries, sql_sets };
+export { sql_queries, sql_sets, substitute_env };

--- a/tests/parse.unit.test.ts
+++ b/tests/parse.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 
-import { sql_queries, sql_sets } from '../src/sql-parse';
+import { sql_queries, sql_sets, substitute_env } from '../src/sql-parse';
 
 describe('Sql query parse', () => {
   beforeEach(() => {
@@ -36,5 +36,52 @@ describe('Sql settings parse', () => {
     const output = { allow_experimental_json_type: '1', allow_experimental_object_new: '1' };
 
     expect(sql_sets(input)).toEqual(output);
+  });
+});
+
+describe('Env var substitution', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('is a no-op when CH_MIGRATIONS_SUBSTITUTE_ENV is not set (backward compatible)', () => {
+    delete process.env.CH_MIGRATIONS_SUBSTITUTE_ENV;
+    process.env.PG_HOST = 'postgres';
+
+    const input = "SOURCE(POSTGRESQL(HOST '${PG_HOST}'))";
+
+    expect(substitute_env(input)).toBe(input);
+  });
+
+  it('substitutes ${VAR} from the environment when enabled', () => {
+    process.env.CH_MIGRATIONS_SUBSTITUTE_ENV = 'true';
+    process.env.PG_HOST = 'postgres';
+    process.env.PG_PORT = '5432';
+
+    const input = "SOURCE(POSTGRESQL(HOST '${PG_HOST}' PORT ${PG_PORT}))";
+    const output = "SOURCE(POSTGRESQL(HOST 'postgres' PORT 5432))";
+
+    expect(substitute_env(input)).toBe(output);
+  });
+
+  it('substitutes the same placeholder multiple times', () => {
+    process.env.CH_MIGRATIONS_SUBSTITUTE_ENV = 'true';
+    process.env.X = 'a';
+
+    expect(substitute_env('${X}-${X}')).toBe('a-a');
+  });
+
+  it('throws when a referenced variable is not set', () => {
+    process.env.CH_MIGRATIONS_SUBSTITUTE_ENV = 'true';
+    delete process.env.MISSING;
+
+    expect(() => substitute_env('${MISSING}')).toThrow(/MISSING/);
   });
 });


### PR DESCRIPTION
Adds opt-in ${VAR} substitution from process.env, gated by CH_MIGRATIONS_SUBSTITUTE_ENV=true (off by default → fully backward compatible). Enables environment-specific, idempotent DDL such as dictionaries whose SOURCE(...) points at a per-environment database.

Safe by design: the checksum is computed on the raw file (before substitution), so a committed migration stays stable across environments and secret rotations; substituted SQL is executed but never persisted to _migrations. Unset referenced variables fail loud.

Includes unit tests and README docs.  
